### PR TITLE
Add required duplex option to RequestInit 

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -28,6 +28,7 @@ export function createNodeRequest(req: IncomingMessage): Request {
   const init: RequestInit = {
     method: req.method,
     headers: createNodeHeaders(req.headers),
+    duplex: 'half'
   }
 
   if (req.method !== 'GET' && req.method !== 'HEAD')


### PR DESCRIPTION
see also nodejs/node#46221 and microsoft/TypeScript-DOM-lib-generator#1483

This will prevent the following runtime error:
```
TypeError: RequestInit: duplex option is required when sending a body.
    at new Request (node:internal/deps/undici/undici:7184:19)
    at createNodeRequest (...node_modules/authey/dist/index.mjs:32:10)
```

This is the fix as suggested by @KararTY in Issue https://github.com/wobsoriano/authey/issues/4

I can confirm vitest passes, the typecheck does fail, but for the known reason that https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1483 mentions regarding the incomplete type in their spec which has fallen behind the actual node implementation.

With the single line added for duplex: 'half', the build in dist works without errors when imported into an Express app and used as middleware.

(PR previously submitted as wobsoriano/authey#6)